### PR TITLE
withClass now uses the proper JS attribute "className" 

### DIFF
--- a/Haste/Deck.hs
+++ b/Haste/Deck.hs
@@ -95,7 +95,7 @@ groupAttrs as s              = PStyle as s
 
 -- | Display the given slide with the given CSS class.
 withClass :: String -> Slide -> Slide
-withClass c = groupAttrs ["class" =: c]
+withClass c = groupAttrs ["className" =: c]
 
 -- | Render a string of text.
 text :: String -> Slide


### PR DESCRIPTION
withClass now uses the proper JS attribute "className" instead of "class".
